### PR TITLE
Fix a compilation error

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,8 +10,6 @@ mod parser;
 mod body;
 mod response;
 
-use hyper::method::Method::Head;
-
 pub use self::request::Head;
 pub use self::response::Response;
 pub use self::context::Context;

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -1,6 +1,7 @@
 use rotor_stream::Buf;
 use hyper::status::StatusCode;
 use hyper::header::{Header, HeaderFormat};
+use hyper::method::Method;
 
 use super::{Head};
 use message::{MessageState, Message, HeaderError};
@@ -40,7 +41,7 @@ impl<'a> Response<'a> {
         // TODO(tailhook) implement Connection: Close,
         // (including explicit one in HTTP/1.0) and maybe others
         MessageState::ResponseStart {
-            body: if head.method == Head { Ignored } else { Normal },
+            body: if head.method == Method::Head { Ignored } else { Normal },
             version: head.version,
         }.with(out_buf)
     }


### PR DESCRIPTION
This is comparing a hyper Method variant not a rotor Head type.

This is a regression in behavior of the compiler. I filed a [bug upstream](https://github.com/rust-lang/rust/issues/30989).