### PR TITLE
use String instead of RequestUri for HTTP path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.rst"
 keywords = ["mio", "http", "websocket", "rotor"]
 homepage = "http://github.com/tailhook/rotor-http"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["paul@colomiets.name"]
 
 [dependencies]

--- a/examples/hello_world_server.rs
+++ b/examples/hello_world_server.rs
@@ -7,7 +7,6 @@ extern crate time;
 use rotor::Scope;
 use rotor_http::status::StatusCode::{self, NotFound};
 use rotor_http::header::ContentLength;
-use rotor_http::uri::RequestUri;
 use rotor_stream::{Deadline, Accept, Stream};
 use rotor_http::server::{RecvMode, Server, Head, Response, Parser};
 use rotor_http::server::{Context as HttpContext};
@@ -68,20 +67,11 @@ impl Server for HelloWorld {
     {
         use self::HelloWorld::*;
         scope.increment();
-        match head.uri {
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/" => {
-                Some(Hello)
-            }
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/num"
-            => {
-                Some(GetNum)
-            }
-            RequestUri::AbsolutePath(p) => {
-                Some(HelloName(p[1..].to_string()))
-            }
-            _ => {
-                Some(PageNotFound)
-            }
+        match &head.path[..] {
+            "/" => Some(Hello),
+            "/num" => Some(GetNum),
+            p if p.starts_with("/") => Some(HelloName(p[1..].to_string())),
+            _ => Some(PageNotFound),
         }
     }
     fn request_received(self, _data: &[u8], res: &mut Response,

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -9,7 +9,6 @@ use std::thread;
 use rotor::Scope;
 use rotor_http::status::StatusCode::{self, NotFound};
 use rotor_http::header::ContentLength;
-use rotor_http::uri::RequestUri;
 use rotor_stream::{Deadline, Accept, Stream};
 use rotor_http::server::{RecvMode, Server, Head, Response, Parser};
 use rotor_http::server::{Context as HttpContext};
@@ -70,20 +69,11 @@ impl Server for HelloWorld {
     {
         use self::HelloWorld::*;
         scope.increment();
-        match head.uri {
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/" => {
-                Some(Hello)
-            }
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/num"
-            => {
-                Some(GetNum)
-            }
-            RequestUri::AbsolutePath(p) => {
-                Some(HelloName(p[1..].to_string()))
-            }
-            _ => {
-                Some(PageNotFound)
-            }
+        match &head.path[..] {
+            "/" => Some(Hello),
+            "/num" => Some(GetNum),
+            p if p.starts_with("/") => Some(HelloName(p[1..].to_string())),
+            _ => Some(PageNotFound),
         }
     }
     fn request_received(self, _data: &[u8], res: &mut Response,

--- a/examples/threaded_reuse_port.rs
+++ b/examples/threaded_reuse_port.rs
@@ -13,7 +13,6 @@ use std::os::unix::io::AsRawFd;
 use rotor::Scope;
 use rotor_http::status::StatusCode::{self, NotFound};
 use rotor_http::header::ContentLength;
-use rotor_http::uri::RequestUri;
 use rotor_stream::{Deadline, Accept, Stream};
 use rotor_http::server::{RecvMode, Server, Head, Response, Parser};
 use rotor_http::server::{Context as HttpContext};
@@ -73,20 +72,11 @@ impl Server for HelloWorld {
     {
         use self::HelloWorld::*;
         scope.increment();
-        match head.uri {
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/" => {
-                Some(Hello)
-            }
-            RequestUri::AbsolutePath(ref p) if &p[..] == "/num"
-            => {
-                Some(GetNum)
-            }
-            RequestUri::AbsolutePath(p) => {
-                Some(HelloName(p[1..].to_string()))
-            }
-            _ => {
-                Some(PageNotFound)
-            }
+        match &head.path[..] {
+            "/" => Some(Hello),
+            "/num" => Some(GetNum),
+            p if p.starts_with("/") => Some(HelloName(p[1..].to_string())),
+            _ => Some(PageNotFound),
         }
     }
     fn request_received(self, _data: &[u8], res: &mut Response,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,3 @@ pub use hyper::status as status;
 pub use hyper::header as header;
 pub use hyper::version as version;
 pub use hyper::method as method;
-pub use hyper::uri as uri;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -1,7 +1,6 @@
 use hyper::version::HttpVersion as Version;
 use hyper::status::StatusCode::{self, BadRequest};
 use hyper::method::Method;
-use hyper::uri::RequestUri;
 use hyper::header::Headers;
 use httparse;
 
@@ -14,13 +13,13 @@ use super::MAX_HEADERS_NUM;
 /// We don't have a request object because it is structured differently
 /// based on whether it is buffered or streaming, chunked or http2, etc.
 ///
-/// Note: we do our base to keep Head object same for HTTP 1-2 and HTTPS
+/// Note: we intend to keep the Head object the same for HTTP 1-2 and HTTPS
 pub struct Head {
     // TODO(tailhook) add source IP address
     pub version: Version,
     pub https: bool,
     pub method: Method,
-    pub uri: RequestUri,
+    pub path: String,
     pub headers: Headers,
 }
 
@@ -37,8 +36,7 @@ impl Head {
                              else { Version::Http10 },
                     method: try!(raw.method.unwrap().parse()
                         .map_err(|_| BadRequest)),
-                    uri: try!(raw.path.unwrap().parse()
-                        .map_err(|_| BadRequest)),
+                    path: raw.path.unwrap().to_owned(),
                     headers: try!(Headers::from_raw(raw.headers)
                         .map_err(|_| BadRequest)),
                 })


### PR DESCRIPTION
Addresses #8. Do not merge yet.

You said the path could be a slice of a buffer, but using `&str` with the current code does not work since the `Transport` in `parse_headers` is borrowed too long mutably by Head. I think it is possible to use slices but `parse_headers` needs to be rewritten. Maybe it would be easier if the headers weren't passed to `request_start` again?