### PR TITLE
Increment counter in hello-world examples.

### DIFF
--- a/examples/hello_world_server.rs
+++ b/examples/hello_world_server.rs
@@ -54,10 +54,11 @@ fn send_string(res: &mut Response, data: &[u8]) {
 
 impl Server for HelloWorld {
     type Context = Context;
-    fn headers_received(head: &Head, _scope: &mut Scope<Context>)
+    fn headers_received(head: &Head, scope: &mut Scope<Context>)
         -> Result<(Self, RecvMode, Deadline), StatusCode>
     {
         use self::HelloWorld::*;
+        scope.increment();
         Ok((match head.path {
             "/" => Hello,
             "/num" => GetNum,

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -56,10 +56,11 @@ fn send_string(res: &mut Response, data: &[u8]) {
 
 impl Server for HelloWorld {
     type Context = Context;
-    fn headers_received(head: &Head, _scope: &mut Scope<Context>)
+    fn headers_received(head: &Head, scope: &mut Scope<Context>)
         -> Result<(Self, RecvMode, Deadline), StatusCode>
     {
         use self::HelloWorld::*;
+        scope.increment();
         Ok((match head.path {
             "/" => Hello,
             "/num" => GetNum,

--- a/examples/threaded_reuse_port.rs
+++ b/examples/threaded_reuse_port.rs
@@ -59,10 +59,11 @@ fn send_string(res: &mut Response, data: &[u8]) {
 
 impl Server for HelloWorld {
     type Context = Context;
-    fn headers_received(head: &Head, _scope: &mut Scope<Context>)
+    fn headers_received(head: &Head, scope: &mut Scope<Context>)
         -> Result<(Self, RecvMode, Deadline), StatusCode>
     {
         use self::HelloWorld::*;
+        scope.increment();
         Ok((match head.path {
             "/" => Hello,
             "/num" => GetNum,


### PR DESCRIPTION
These calls were lost in tailhook/rotor-http@7a24c51.

They could instead go in `request_start` or `request_received`. Let me know if you think that makes for a better example.