### PR TITLE
remove need for typed hyper headers

### DIFF
--- a/examples/hello_world_server.rs
+++ b/examples/hello_world_server.rs
@@ -5,7 +5,6 @@ extern crate time;
 
 use rotor::Scope;
 use rotor_http::status::StatusCode::{self, NotFound};
-use rotor_http::header::ContentLength;
 use rotor_http::server::{RecvMode, Server, Head, Response};
 use rotor_http::server::{Context as HttpContext};
 use rotor_http::{Deadline, ServerFsm};
@@ -45,7 +44,7 @@ enum HelloWorld {
 
 fn send_string(res: &mut Response, data: &[u8]) {
     res.status(StatusCode::Ok);
-    res.add_header(ContentLength(data.len() as u64)).unwrap();
+    res.add_length(data.len() as u64).unwrap();
     res.done_headers().unwrap();
     res.write_body(data);
     res.done();

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -8,7 +8,6 @@ use std::thread;
 use rotor::Scope;
 use rotor_http::{Deadline, ServerFsm};
 use rotor_http::status::StatusCode::{self, NotFound};
-use rotor_http::header::ContentLength;
 use rotor_http::server::{RecvMode, Server, Head, Response};
 use rotor_http::server::{Context as HttpContext};
 use rotor::mio::tcp::TcpListener;
@@ -47,7 +46,7 @@ enum HelloWorld {
 
 fn send_string(res: &mut Response, data: &[u8]) {
     res.status(StatusCode::Ok);
-    res.add_header(ContentLength(data.len() as u64)).unwrap();
+    res.add_length(data.len() as u64).unwrap();
     res.done_headers().unwrap();
     res.write_body(data);
     res.done();

--- a/examples/threaded_reuse_port.rs
+++ b/examples/threaded_reuse_port.rs
@@ -12,7 +12,6 @@ use std::os::unix::io::AsRawFd;
 use rotor::Scope;
 use rotor_http::{Deadline, ServerFsm};
 use rotor_http::status::StatusCode::{self, NotFound};
-use rotor_http::header::ContentLength;
 use rotor_http::server::{RecvMode, Server, Head, Response};
 use rotor_http::server::{Context as HttpContext};
 use time::Duration;
@@ -50,7 +49,7 @@ enum HelloWorld {
 
 fn send_string(res: &mut Response, data: &[u8]) {
     res.status(StatusCode::Ok);
-    res.add_header(ContentLength(data.len() as u64)).unwrap();
+    res.add_length(data.len() as u64).unwrap();
     res.done_headers().unwrap();
     res.write_body(data);
     res.done();

--- a/examples/two_servers.rs
+++ b/examples/two_servers.rs
@@ -6,7 +6,6 @@ extern crate time;
 use rotor::{Scope, Compose2};
 use rotor_http::{Deadline, ServerFsm};
 use rotor_http::status::StatusCode::{self};
-use rotor_http::header::ContentLength;
 use rotor_http::server::{RecvMode, Server, Head, Response};
 use rotor::mio::tcp::{TcpListener};
 use time::Duration;
@@ -42,7 +41,7 @@ impl rotor_http::server::Context for Context {
 
 fn send_string(res: &mut Response, data: &[u8]) {
     res.status(StatusCode::Ok);
-    res.add_header(ContentLength(data.len() as u64)).unwrap();
+    res.add_length(data.len() as u64).unwrap();
     res.done_headers().unwrap();
     res.write_body(data);
     res.done();

--- a/src/client/parser.rs
+++ b/src/client/parser.rs
@@ -426,7 +426,7 @@ impl<M, S> Protocol for Parser<M, S>
                 }
             }
             ReadHeaders {..} => unreachable!(),
-            Response { progress, machine, deadline, request }  => {
+            Response { .. }  => {
                 unimplemented!();
             }
             Idle => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,8 @@ mod headers;
 
 pub use rotor_stream::{Deadline, Accept, Stream};
 pub use hyper::status as status;
-pub use hyper::header as header;
 pub use hyper::version as version;
 pub use hyper::method as method;
-pub use hyper::uri as uri;
 
 /// A shortcut type for server state machine
 pub type ServerFsm<M, L> = Accept<Stream<

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -1,7 +1,5 @@
 use hyper::status::StatusCode;
-use hyper::header::{ContentLength, ContentType};
 use time::Duration;
-use hyper::mime::{Mime, TopLevel, SubLevel};
 
 use super::Response;
 
@@ -12,9 +10,8 @@ pub trait Context {
         let data = format!("<h1>{}</h1>\n\
             <p><small>Served for you by rotor-http</small></p>\n", code);
         let bytes = data.as_bytes();
-        response.add_header(ContentLength(bytes.len() as u64)).unwrap();
-        response.add_header(ContentType(
-            Mime(TopLevel::Text, SubLevel::Html, vec![]))).unwrap();
+        response.add_length(bytes.len() as u64).unwrap();
+        response.add_header("Content-Type", b"text/html").unwrap();
         response.done_headers().unwrap();
         response.write_body(bytes);
         response.done();

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -1,6 +1,5 @@
 use rotor_stream::Buf;
 use hyper::status::StatusCode;
-use hyper::header::{Header, HeaderFormat};
 use hyper::version::HttpVersion;
 
 use message::{MessageState, Message, HeaderError};
@@ -84,15 +83,17 @@ impl<'a> Response<'a> {
     pub fn status(&mut self, code: StatusCode) {
         self.0.response_status(code)
     }
-    /// Add header to response
+    /// Add header to message
     ///
     /// Header is written into the output buffer immediately. And is sent
     /// as soon as the next loop iteration
     ///
-    /// Fails when invalid combination of headers is encountered. Note we
-    /// don't validate all the headers but only security-related ones like
-    /// double content-length and content-length with the combination of
-    /// transfer-encoding.
+    /// `Content-Length` header must be send using the `add_length` method
+    /// and `Transfer-Encoding: chunked` must be set with the `add_chunked`
+    /// method. These two headers are important for the security of HTTP.
+    ///
+    /// Note that there is currently no way to use a transfer encoding other
+    /// than chunked.
     ///
     /// We return Result here to make implementing proxies easier. In the
     /// application handler it's okay to unwrap the result and to get
@@ -100,13 +101,39 @@ impl<'a> Response<'a> {
     ///
     /// # Panics
     ///
-    /// * Panics when add_header is called in the wrong state.
-    /// * Panics on unsupported transfer encoding
-    ///
-    pub fn add_header<H: Header+HeaderFormat>(&mut self, header: H)
+    /// Panics when `add_header` is called in the wrong state.
+    pub fn add_header(&mut self, name: &str, value: &[u8])
         -> Result<(), HeaderError>
     {
-        self.0.add_header(header)
+        self.0.add_header(name, value)
+    }
+    /// Add a content length to the message.
+    ///
+    /// The `Content-Length` header is written to the output buffer immediately.
+    /// It is checked that there are no other body length headers present in the
+    /// message. When the body is send the length is validated.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `add_length` is called in the wrong state.
+    pub fn add_length(&mut self, n: u64)
+        -> Result<(), HeaderError>
+    {
+        self.0.add_length(n)
+    }
+    /// Sets the transfer encoding to chunked.
+    ///
+    /// Writes `Transfer-Encoding: chunked` to the output buffer immediately.
+    /// It is assured that there is only one body length header is present
+    /// and the body is written in chunked encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `add_chunked` is called in the wrong state.
+    pub fn add_chunked(&mut self)
+        -> Result<(), HeaderError>
+    {
+        self.0.add_chunked()
     }
     /// Returns true if at least `status()` method has been called
     ///


### PR DESCRIPTION
Uses &str for header names and &[u8] for values. Adds
special methods for Content-Length and Transfer-Encoding
headers.

#15 