### PR TITLE
Reorganize the server exports.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,9 +7,8 @@ use std::net::ToSocketAddrs;
 use std::time::Duration;
 
 use rotor::{Scope, Time};
-use rotor_http::client::{connect_tcp, Request, Head, Client, RecvMode};
-use rotor_http::client::{Connection, Requester, Task};
-use rotor_http::Version::Http11;
+use rotor_http::client::{connect_tcp, Request, Head, Client, RecvMode,
+    Connection, Requester, Task, Version};
 
 struct Context;
 
@@ -56,7 +55,7 @@ impl Client for Cli {
 impl Requester for Req {
     type Context = Context;
     fn prepare_request(self, req: &mut Request) -> Option<Self> {
-        req.start("GET", &self.0, Http11);
+        req.start("GET", &self.0, Version::Http11);
         req.done_headers().unwrap();
         req.done();
         Some(self)

--- a/examples/hello_world_server.rs
+++ b/examples/hello_world_server.rs
@@ -4,8 +4,7 @@ extern crate rotor_http;
 use std::time::Duration;
 
 use rotor::{Scope, Time};
-use rotor_http::server::{RecvMode, Server, Head, Response};
-use rotor_http::{ServerFsm};
+use rotor_http::server::{RecvMode, Server, Head, Response, Fsm};
 use rotor::mio::tcp::TcpListener;
 
 
@@ -125,7 +124,7 @@ fn main() {
     });
     let lst = TcpListener::bind(&"127.0.0.1:3000".parse().unwrap()).unwrap();
     loop_inst.add_machine_with(|scope| {
-        ServerFsm::<HelloWorld, _>::new(lst, scope)
+        Fsm::<HelloWorld, _>::new(lst, scope)
     }).unwrap();
     loop_inst.run().unwrap();
 }

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -7,8 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use rotor::{Scope, Time};
-use rotor_http::{ServerFsm};
-use rotor_http::server::{RecvMode, Server, Head, Response};
+use rotor_http::server::{Fsm, RecvMode, Server, Head, Response};
 use rotor::mio::tcp::TcpListener;
 
 
@@ -134,7 +133,7 @@ fn main() {
                 counter: 0,
             });
             loop_inst.add_machine_with(|scope| {
-                ServerFsm::<HelloWorld, _>::new(listener, scope)
+                Fsm::<HelloWorld, _>::new(listener, scope)
             }).unwrap();
             loop_inst.run().unwrap();
         }));

--- a/examples/threaded_reuse_port.rs
+++ b/examples/threaded_reuse_port.rs
@@ -10,8 +10,7 @@ use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
 use rotor::{Scope, Time};
-use rotor_http::{ServerFsm};
-use rotor_http::server::{RecvMode, Server, Head, Response};
+use rotor_http::server::{Fsm, RecvMode, Server, Head, Response};
 
 
 struct Context {
@@ -147,7 +146,7 @@ fn main() {
                 counter: 0,
             });
             loop_inst.add_machine_with(|scope| {
-                ServerFsm::<HelloWorld, _>::new(listener, scope)
+                Fsm::<HelloWorld, _>::new(listener, scope)
             }).unwrap();
             loop_inst.run().unwrap();
         }));

--- a/examples/todobackend.rs
+++ b/examples/todobackend.rs
@@ -25,14 +25,12 @@ extern crate rotor_http;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::str;
+use std::str::from_utf8;
 use std::time::Duration;
 
 use rotor::{Scope, Time};
-use rotor_http::ServerFsm;
-use rotor_http::server;
-use rotor_http::server::{RecvMode, Server, Head, Response};
 use rotor::mio::tcp::TcpListener;
+use rotor_http::server::{self, Fsm, Head, RecvMode, Response, Server};
 
 /// Represents a single Todo entry.
 ///
@@ -197,7 +195,7 @@ impl Server for TodoBackend {
         -> Option<Self>
     {
         use self::TodoBackend::*;
-        let text_data = str::from_utf8(data).unwrap();
+        let text_data = from_utf8(data).unwrap();
         let (status, reason, body) = match self {
             List => (200, "OK", Cow::Owned(serde_json::to_string(&scope.list()).unwrap().into_bytes())),
             Create => {
@@ -303,7 +301,7 @@ fn main() {
     });
     let lst = TcpListener::bind(&"127.0.0.1:3000".parse().unwrap()).unwrap();
     loop_inst.add_machine_with(|scope| {
-        ServerFsm::<TodoBackend, _>::new(lst, scope)
+        Fsm::<TodoBackend, _>::new(lst, scope)
     }).unwrap();
     loop_inst.run().unwrap();
 }

--- a/examples/two_servers.rs
+++ b/examples/two_servers.rs
@@ -4,8 +4,7 @@ extern crate rotor_http;
 use std::time::Duration;
 
 use rotor::{Scope, Compose2, Time};
-use rotor_http::{ServerFsm};
-use rotor_http::server::{RecvMode, Server, Head, Response};
+use rotor_http::server::{Fsm, RecvMode, Server, Head, Response};
 use rotor::mio::tcp::{TcpListener};
 
 
@@ -141,10 +140,10 @@ fn main() {
         counter: 0,
     });
     loop_inst.add_machine_with(|scope| {
-        ServerFsm::<Incr, _>::new(lst1, scope).wrap(Compose2::A)
+        Fsm::<Incr, _>::new(lst1, scope).wrap(Compose2::A)
     }).unwrap();
     loop_inst.add_machine_with(|scope| {
-        ServerFsm::<Get, _>::new(lst2, scope).wrap(Compose2::B)
+        Fsm::<Get, _>::new(lst2, scope).wrap(Compose2::B)
     }).unwrap();
     loop_inst.run().unwrap();
 }

--- a/src/client/head.rs
+++ b/src/client/head.rs
@@ -1,5 +1,5 @@
 use httparse;
-use Version;
+use version::Version;
 
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,6 +19,7 @@ mod protocol;
 mod parser;
 mod connection;
 
+pub use version::Version;
 pub use self::request::{Request};
 pub use self::protocol::{Client, Requester, Task};
 pub use self::head::Head;

--- a/src/client/parser.rs
+++ b/src/client/parser.rs
@@ -17,7 +17,7 @@ use super::head::BodyKind;
 use message::{MessageState};
 use recvmode::RecvMode;
 use headers;
-use Version;
+use version::Version;
 
 
 #[derive(Debug)]

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,7 +1,7 @@
 use rotor_stream::Buf;
 
 use message::{MessageState, Message, HeaderError};
-use Version;
+use version::Version;
 
 
 pub struct Request<'a>(Message<'a>, pub Option<bool>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,3 @@ mod message;
 mod recvmode;
 mod headers;
 mod version;
-
-pub use version::Version;
-
-pub use rotor_stream::{Accept, Stream};
-
-/// A shortcut type for server state machine
-pub type ServerFsm<M, L> = Accept<Stream<
-    server::Parser<M, <L as rotor::mio::TryAccept>::Output>>, L>;

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,7 +3,7 @@ use std::ascii::AsciiExt;
 
 use rotor_stream::Buf;
 
-use Version;
+use version::Version;
 
 quick_error! {
     #[derive(Debug)]
@@ -442,7 +442,7 @@ impl<'a> Message<'a> {
 mod test {
     use rotor_stream::Buf;
     use super::{Message, MessageState, Body};
-    use Version;
+    use version::Version;
 
     #[test]
     fn message_size() {

--- a/src/server/body.rs
+++ b/src/server/body.rs
@@ -1,6 +1,19 @@
+/// The expected type of request body, if any.
+///
+/// After the header fields are parsed the request body kind
+/// is decided. This information can be useful for servers
+/// to decide if a request should be accepted and if the request
+/// should be received in buffered or progressive mode.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BodyKind {
+    /// Fixed number of bytes body.
+    ///
+    /// A value of `Fixed(0)` is used for requests without body.
     Fixed(u64),
-    Upgrade,
+    /// The message body is transmitted as several chunks.
+    ///
+    /// The size of the message body is not yet known.
     Chunked,
+    /// Reserved for future usage.
+    Upgrade,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,19 +3,25 @@
 //! Currently there is only HTTP/1.x implementation. We want to provide
 //! HTTP/2.0 and HTTPS
 //!
-mod request;
-mod protocol;
-mod context;
-mod parser;
-mod body;
-mod response;
+use rotor::mio::TryAccept;
+pub use rotor_stream::{Accept, Stream};
 
+pub use recvmode::RecvMode;
+pub use version::Version;
+pub use self::body::BodyKind;
+pub use self::context::Context;
+pub use self::parser::Parser;
+pub use self::protocol::Server;
 pub use self::request::Head;
 pub use self::response::Response;
-pub use self::context::Context;
-pub use self::protocol::{Server};
-pub use self::parser::Parser;
-pub use recvmode::RecvMode;
+
+mod body;
+mod context;
+mod parser;
+mod protocol;
+mod request;
+mod response;
+
 
 // TODO(tailhook) MAX_HEADERS_SIZE can be moved to Context
 // (i.e. made non-constant), but it's more of a problem for MAX_HEADERS_NUM
@@ -23,13 +29,21 @@ pub use recvmode::RecvMode;
 // so performance will degrade. Customizing MAX_HEADERS_SIZE is not very
 // useful on it's own
 
-/// Note httparse requires we preallocate array of this size so be wise
+/// The maximum allowed number of headers in a request.
+///
+/// Note httparse requires we preallocate array of this size so be wise.
 pub const MAX_HEADERS_NUM: usize = 256;
+
+/// The maximum size of request headers in bytes.
+///
 /// This one is not preallocated, but too large buffer is of limited use
-/// because of previous parameter.
+/// because of `MAX_HEADERS_NUM` parameter.
 pub const MAX_HEADERS_SIZE: usize = 16384;
-/// Maximum length of chunk size line. it would be okay with 12 bytes, but in
-/// theory there might be some extensions which we probably should skip
+
+/// The maximum length of chunk size line in bytes.
+///
+/// It would be okay with 12 bytes, but in theory there might be some extensions
+/// which we skip. Note that the header is also used for padding.
 ///
 /// Note: we don't have a limit on chunk body size. In buffered request mode
 /// it's limited by either memory or artificial limit returned from handler.
@@ -37,3 +51,5 @@ pub const MAX_HEADERS_SIZE: usize = 16384;
 /// request handler is able to handle it.
 pub const MAX_CHUNK_HEAD: usize = 128;
 
+/// Shortcut type for server state machines.
+pub type Fsm<M, L> = Accept<Stream<Parser<M, <L as TryAccept>::Output>>, L>;

--- a/src/server/parser.rs
+++ b/src/server/parser.rs
@@ -8,7 +8,7 @@ use rotor::{Scope, Time};
 use rotor::mio::tcp::TcpStream;
 use rotor_stream::{Exception, Intent, Protocol, StreamSocket, Transport};
 
-use Version;
+use version::Version;
 use headers;
 use message::MessageState;
 use recvmode::RecvMode;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use httparse;
 
 use super::body::BodyKind;
-use Version;
+use version::Version;
 
 
 #[derive(Debug)]

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -1,7 +1,7 @@
 use rotor_stream::Buf;
 
 use message::{MessageState, Message, HeaderError};
-use Version;
+use version::Version;
 
 
 /// This response is returned when Response is dropping without writing

--- a/src/version.rs
+++ b/src/version.rs
@@ -20,7 +20,7 @@ pub enum Version {
 
 impl Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Version::*;
+        use self::Version::*;
         f.write_str(match *self {
             Http10 => "HTTP/1.0",
             Http11 => "HTTP/1.1",


### PR DESCRIPTION
Before this change some server types would be exported at the
crate root. Now all public server types are exposed from
server::*. Server ReadBody made public, probably an oversight.
For symmetry with the client the ServerFsm was renamed to Fsm.
Also both client and server now export the HTTP Version enum.
More documentation. This is BREAKING CHANGE.