### PR TITLE
Handle wakeup for all Parser states

### DIFF
--- a/src/client/parser.rs
+++ b/src/client/parser.rs
@@ -658,7 +658,7 @@ mod test {
             _scope: &mut Scope<<Self::Requester as Requester>::Context>)
             -> Task<Cli>
         {
-            Task::Request(self, Req)
+            unimplemented!();
         }
         fn timeout(self,
             _connection: &Connection,

--- a/src/client/parser.rs
+++ b/src/client/parser.rs
@@ -561,20 +561,15 @@ impl<M, S> Protocol for Parser<M, S>
     {
         use self::ParserImpl::*;
         match self.1 {
-            // skip the event, will child state machine when connected
-            me@Connecting(..) => me.intent(self.0, scope),
-            // skip the event, will child state machine when connected
-            me@Flushing(..) => me.intent(self.0, scope),
             Idle(..) => {
                 // TODO(tailhook) propagate same idle deadline
                 maybe_new_request(transport,
                     self.0.wakeup(&Connection {
                         idle: true,
                     }, scope), scope)
-            }
-            _ => {
-                unimplemented!();
-            }
+            },
+            // skip the event, will child state machine when idle
+            me@_ => me.intent(self.0, scope)
         }
     }
 }

--- a/src/client/parser.rs
+++ b/src/client/parser.rs
@@ -572,8 +572,10 @@ impl<M, S> Protocol for Parser<M, S>
                         idle: true,
                     }, scope), scope)
             },
-            ReadHeaders { machine, request, .. } => {
-                let mut req = request.with(transport.output());
+            ReadHeaders { machine, request, is_head } => {
+                let mut req: Request = request.with(transport.output());
+                req.1 = is_head;
+
                 match machine.wakeup(&mut req, scope) {
                     Some(m) => {
                         ReadHeaders {


### PR DESCRIPTION
Fixes #45 

I've just used the `intent` function like you've done above for other states. Not sure if this is the correct way to handle all other states except `Idle`.

I've done a simple test binary spanking a connection with wakeups and it's handled them as expected instead of panicking. Should I write a test function for this? If so how should I go about it?
