### PR TITLE
Export rotor_http::message to allow matching errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate rotor_stream;
 
 pub mod server;
 pub mod client;
-mod message;
+pub mod message;
 mod recvmode;
 mod headers;
 mod version;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,5 @@
+//! HTTP Messages and Errors
+//!
 use std::io::Write;
 use std::ascii::AsciiExt;
 


### PR DESCRIPTION
I was trying to handle the error returned by `add_header` and noticed it returns `rotor_http::message::HeaderError`, which isn't exported. This patch makes `rotor_http::message` public.

```
error: module `message` is private
 --> src/something.rs:2:5
  |
2 | use rotor_http::message::HeaderError;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```